### PR TITLE
Require gnat>=14

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -8,3 +8,6 @@ maintainers-logins = ["damaki"]
 licenses = "Apache-2.0"
 website = "https://github.com/damaki/libcrc"
 tags = ["crc", "crc32", "spark", "error-checking"]
+
+[[depends-on]]
+gnat = ">=14"


### PR DESCRIPTION
libcrc uses the Always_Terminates aspect, which was added in GNAT FSF 14. Earlier versions of the compiler emit warnings that the aspect is unrecognised.